### PR TITLE
Fix regressions with controllers

### DIFF
--- a/admin/src/services/strapi/index.ts
+++ b/admin/src/services/strapi/index.ts
@@ -107,17 +107,19 @@ const setMuxAsset = async (muxAsset:MuxAssetUpdate): Promise<MuxAsset> => {
 };
 
 const deleteMuxAsset = async (muxAsset: MuxAsset): Promise<any> => {
-  const body = new FormData();
-  body.append("id", muxAsset.id.toString());
-  body.append("asset_id", muxAsset.asset_id || '');
-  body.append("upload_id", muxAsset.upload_id);
-  body.append("delete_on_mux", "true");
+  const body = JSON.stringify({
+    id: muxAsset.id,
+    delete_on_mux: true
+  });
 
   const url = `${getServiceUri()}/${pluginId}/deleteMuxAsset`;
 
   const response = await fetch(url, {
     method: "POST",
-    headers: { 'Authorization': `Bearer ${getJwtToken()}` },
+    headers: {
+      'Contet-Type': 'application/json',
+      'Authorization': `Bearer ${getJwtToken()}`
+    },
     body
   });
 

--- a/server/controllers/mux-asset.ts
+++ b/server/controllers/mux-asset.ts
@@ -1,4 +1,3 @@
-import { parseMultipartData } from '@strapi/utils';
 import { Context } from 'koa';
 
 import pluginId from './../../admin/src/pluginId';
@@ -41,10 +40,10 @@ const find = async (ctx: Context) => {
   };
 };
 
-const findOne = async (ctx:Context) => {
+const findOne = async (ctx: Context) => {
   const { id } = ctx.params;
-  
-  return await strapi.entityService.findOne({ id }, { model });
+
+  return await strapi.entityService.findOne(model, id);
 };
 
 const count = (ctx: Context) => {
@@ -60,23 +59,14 @@ const count = (ctx: Context) => {
 };
 
 const create = async (ctx: Context) => {
-  let entity;
-
-  if (ctx.is('multipart')) {
-    const { data, files } = parseMultipartData(ctx);
-
-    entity = await strapi.entityService.create({ data, files }, { model });
-  } else {
-    entity = await strapi.entityService.create({ data: ctx.request.body }, { model });
-  }
-
-  return entity;
+  const { body } = ctx.request;
+  
+  return await strapi.entityService.create(model, { data: body });
 };
 
 const update = async (ctx:Context) => {
   const { id } = ctx.params;
-
-  const { data: body } = parseMultipartData(ctx);
+  const { body } = ctx.request;
 
   const data: { title?: string, isReady?: boolean } = {};
   
@@ -93,7 +83,7 @@ const update = async (ctx:Context) => {
 const del = async (ctx:Context) => {
   const { id } = ctx.params;
 
-  return await strapi.entityService.delete({ params: { id } }, { model });
+  return await strapi.entityService.delete(model, id);
 };
 
 export = {
@@ -104,4 +94,4 @@ export = {
   create,
   update,
   del
-}
+};


### PR DESCRIPTION
- Updated mux-asset.findOne with proper entity service syntax
- Updated mux-asset.create to succinctly use entity service
- Updated mux-asset.update to remove unnecessary parseMultipartData
- Updated mux-asset.del with proper entity service syntax
- Changed field validation on deleteMuxAsset from upload_id to id
- deleteMuxAsset now resolves mux-asset entry from id
- If mux-asset doesnt have asset_id, query it from Mux using upload_id
- Updated plugin UI to use JSON for delete rather than FormData