### PR TITLE
Fix typo in "Contet-Type"

### DIFF
--- a/admin/src/services/strapi/index.ts
+++ b/admin/src/services/strapi/index.ts
@@ -117,7 +117,7 @@ const deleteMuxAsset = async (muxAsset: MuxAsset): Promise<any> => {
   const response = await fetch(url, {
     method: "POST",
     headers: {
-      'Contet-Type': 'application/json',
+      'Content-Type': 'application/json',
       'Authorization': `Bearer ${getJwtToken()}`
     },
     body

--- a/server/controllers/mux.ts
+++ b/server/controllers/mux.ts
@@ -122,7 +122,7 @@ const submitRemoteUpload = async (ctx:Context) => {
 };
 
 const deleteMuxAsset = async (ctx: Context) => {
-  const { id, delete_on_mux } = JSON.parse(ctx.request.body);
+  const { id, delete_on_mux } = ctx.request.body;
 
   if(!id) {
     ctx.badRequest("ValidationError", { errors: { "id": ["id needs to be defined"]}});


### PR DESCRIPTION
There's a typo in `deleteMuxAsset` when sending the request to Strapis backend. The "Content-Type"-Header is written as "Contet-Type".
After fixing the typo, the `JSON.parse` in the backend-code isn't required anymore.