### PR TITLE
Move prepare to preprepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "clean": "rimraf dist/",
     "copy-files": "copyfiles README.md yarn.lock dist/",
     "dev": "tsc --watch",
-    "prepare": "husky install"
+    "preprepare": "husky install"
   },
   "dependencies": {
     "@mux/mux-node": "^6.4.0",


### PR DESCRIPTION
- prepare script was failing on npm publish which we didn't need
- preprepare doesn't get executed on npm publish, does on install