### PR TITLE
add key to assets list

### DIFF
--- a/admin/src/components/asset-grid/index.tsx
+++ b/admin/src/components/asset-grid/index.tsx
@@ -19,7 +19,7 @@ const AssetGrid = (props: Props) => {
   if (muxAssets === undefined) return null;
 
   const assets = muxAssets.map((muxAsset) => (
-    <GridItem col={3} xs={12} s={6}>
+    <GridItem col={3} xs={12} s={6} key={muxAsset?.asset_id}>
       <AssetCard muxAsset={muxAsset} onClick={onMuxAssetClick} />
     </GridItem>
   ));


### PR DESCRIPTION
Key is missing in the array map code which is causing repeated thumbnails when page is changed.

Keys help React identify which items have changed, are added, or are removed. Keys should be given to the elements inside the array to give the elements a stable identity

Reference https://react.dev/learn/rendering-lists#keeping-list-items-in-order-with-key