### PR TITLE
Obfuscaste react-router-dom types

### DIFF
--- a/admin/src/containers/App/index.tsx
+++ b/admin/src/containers/App/index.tsx
@@ -9,11 +9,8 @@ import HomePage from '../HomePage';
 const App = () => {
   return (
     <Main>
-      {/* @ts-expect-error issue with react-router-dom typings */}
       <Switch>
-        {/* @ts-expect-error issue with react-router-dom typings */}
         <Route path={`/plugins/${pluginId}`} component={HomePage} exact />
-        {/* @ts-expect-error issue with react-router-dom typings */}
         <Route component={NotFound} />
       </Switch>
     </Main>

--- a/types/globals.d.ts
+++ b/types/globals.d.ts
@@ -4,3 +4,5 @@ declare module '*.svg' {
   const content: any;
   export default content;
 }
+
+declare module 'react-router-dom';


### PR DESCRIPTION
- react-router-dom v5.x doesn't ship with types
- Local dev throws errors because of this
- We do this to swallow any errors